### PR TITLE
Process SIGTERM to make `docker stop` graceful

### DIFF
--- a/src/utils/signal.rs
+++ b/src/utils/signal.rs
@@ -1,18 +1,40 @@
 use tokio::signal;
+use tracing::warn;
 
+/// Waits for SIGINT or SIGTERM and triggers graceful shutdown.
 pub async fn shutdown_signal() {
+    #[cfg(unix)]
+    let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())
+        .expect("failed to install SIGTERM handler");
+
     let ctrl_c = async {
         signal::ctrl_c()
             .await
             .expect("failed to install Ctrl+C handler")
     };
 
+    #[cfg(unix)]
+    let terminate = async {
+        sigterm.recv().await;
+    };
+
+    #[cfg(unix)]
     tokio::select! {
         _ = ctrl_c => {
-            #[cfg(not(windows))]
             println!();
-            tracing::info!("Ctrl+C recieved. Please wait, this could take a while.");
-            std::process::exit(0);
+            warn!("SIGINT received, shutting down gracefully...");
+        }
+        _ = terminate => {
+            warn!("SIGTERM received, shutting down gracefully...");
         }
     }
+
+    #[cfg(not(unix))]
+    tokio::select! {
+        _ = ctrl_c => {
+            warn!("SIGINT (Ctrl+C) received, shutting down gracefully...");
+        }
+    }
+
+    std::process::exit(0);
 }


### PR DESCRIPTION
Old implementation processed the Ctrl+C(SIGINT) but not the SIGTERM, which docker sends to container's app in order to give it a chance to exit gracefully. Well, use it now! 